### PR TITLE
[fix] footerのリンクボタンが押せない不具合を修正

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -6,7 +6,7 @@ function Footer() {
   let date = new Date();
   let year = date.getFullYear();
   return (
-    <Container fluid className="footer">
+    <Container fluid className="footer" style={{ position: "relative" }}>
       <Row>
         <Col md="4" className="footer-copywright">
           <h3>IT系学生団体 Tech.Uni</h3>

--- a/src/style.css
+++ b/src/style.css
@@ -543,6 +543,7 @@ button:focus {
     bottom: 0 !important;
     padding-top: 10px !important;
     padding-bottom: 8px !important;
+    z-index: 3;
 }
 
 .footer-copywright {


### PR DESCRIPTION
close #44 

## fix
- footerのz-indexを0より大きくして、footerおよびボタンなどの内容物が前面に描画されるように修正
  - Homeにおいて背景のts-particleがfooterの上に乗ってしまい、リンクボタンが押せない不具合( #44 )の対応