### PR TITLE
fix: sponserロゴのパス修正

### DIFF
--- a/src/components/Home/SponserLogoSlider.jsx
+++ b/src/components/Home/SponserLogoSlider.jsx
@@ -8,7 +8,7 @@ import Kobe from "../../assets/Sponsor/kobe.png";
 import Mynavi from "../../assets/Sponsor/mynavi.png";
 import Paiza from "../../assets/Sponsor/paiza.png";
 import Web3Career from "../../assets/Sponsor/web3-career.png";
-import Stores from "../../assets/Sponsor/stores.png";
+import Stores from "../../assets/Sponsor/STORES.png";
 import SponsorLogo from "../Sponsor/SponsorLogo";
 import SlideContainer from "./slider";
 

--- a/src/components/Sponsor/Sponsor.jsx
+++ b/src/components/Sponsor/Sponsor.jsx
@@ -9,7 +9,7 @@ import Kobe from "../../assets/Sponsor/kobe.png";
 import Paiza from "../../assets/Sponsor/paiza.png";
 import Web3Career from "../../assets/Sponsor/web3-career.png";
 import Mynavi from "../../assets/Sponsor/mynavi.png";
-import Stores from "../../assets/Sponsor/stores.png";
+import Stores from "../../assets/Sponsor/STORES.png";
 import SponsorLogo from "./SponsorLogo";
 
 function Sponsor() {


### PR DESCRIPTION
#86 についてローカルでは正常作動したのですが、
action上でパスの大文字・小文字のエラーがでたので修正