### PR TITLE
Revert "fix: homeのfooter下揃え"

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -8,7 +8,7 @@ import Type from "./Type";
 
 function Home() {
   return (
-          <section style={{display: "flex", flexDirection: "column"}}>
+          <section>
             <Container fluid className="home-section" id="home">
               <Particle/>
               <Container className="home-content">

--- a/src/style.css
+++ b/src/style.css
@@ -346,7 +346,6 @@ section {
   position: relative;
   padding-bottom: 70px !important;
   padding-top: 70px !important;
-  flex-grow: 1;
 }
 
 .home-about-description {
@@ -458,8 +457,8 @@ section {
 }
 
 .sponsor-logo {
-  width: 150px;
-  margin: 0 30px;
+    width: 150px;
+    margin: 0 30px;
 }
 
 /* -------- */
@@ -649,7 +648,6 @@ section {
   width: 200px;
   height: 200px;
 }
-
 /* --------- */
 /* Projects */
 /* --------- */


### PR DESCRIPTION
Reverts TechUni2020/TechUni-hp#116

## reason
- tsparticlesが動かなくなる
  - sectionのdisplay:flexによりcanvasの前にsectionがきて、pointer-event:initialが効果しなくなる